### PR TITLE
Remove-missing-font-warnings

### DIFF
--- a/web/themes/custom/quitpath/templates/includes/preload.twig
+++ b/web/themes/custom/quitpath/templates/includes/preload.twig
@@ -7,8 +7,3 @@
  * -quitpath _path: Returns the path to the Quitpath theme.
  */
 #}
-
-<link rel="preload" href="{{ quitpath_path }}/fonts/metropolis/Metropolis-Regular.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="preload" href="{{ quitpath_path }}/fonts/metropolis/Metropolis-SemiBold.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="preload" href="{{ quitpath_path }}/fonts/metropolis/Metropolis-Bold.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="preload" href="{{ quitpath_path }}/fonts/lora/lora-v14-latin-regular.woff2" as="font" type="font/woff2" crossorigin>


### PR DESCRIPTION
We have updated the following file to fix the font-missing/not-in-use warning

location: /web/themes/custom/quitpath/templates/includes/preload.twig


